### PR TITLE
Adding "scss/_variables.scss"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
         "css/materialdesignicons.css",
         "fonts/*",
         "css/*",
+        "scss/_variables.scss",
         "scss/*",
         "package.json",
         "preview.html"


### PR DESCRIPTION
Adding "scss/_variables.scss" before "scss/*" to prevent automatically injectors to add any ".scss" that depends on any variable before the "scss/_variables.scss".
